### PR TITLE
Add LinkedIn scraping feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Os principais comandos podem ser vistos no menu do aplicativo ou acessando o das
 - `ffmpeg` instalado no sistema (necessário para transcrição de áudio)
 - Conta e chave da [ElevenLabs](https://elevenlabs.io/) para recursos de voz (opcional)
 - [Ollama](https://ollama.ai/) instalado para executar o modelo local de LLM
+- [`Playwright`](https://playwright.dev/) instalado (após `npm install` execute `npx playwright install` para baixar os navegadores)
 
 ## Instalação
 
@@ -37,6 +38,7 @@ Os principais comandos podem ser vistos no menu do aplicativo ou acessando o das
 
    ```bash
    npm install
+   npx playwright install
    ```
    
 3. **Instale o MongoDB** (Ubuntu/Debian)
@@ -99,6 +101,7 @@ Após iniciar, envie `!menu` ou os atalhos numéricos para ver as opções. Entr
 - `!foto` ou `!calorias` enviados com uma imagem
 - `!voz` para alternar respostas por voz ou texto
 - `!recurso` para exibir detalhes do sistema onde o bot está rodando
+- `!linkedin <URL>` para resumir dados públicos de um perfil
 
 O endpoint `/dashboard` oferece uma página simples com as informações do bot e comandos disponíveis.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "nodejs-whisper": "^0.1.19",
         "ollama": "^0.5.1",
         "p-limit": "^6.2.0",
+        "playwright": "^1.42.0",
         "qrcode-terminal": "^0.12.0",
         "systeminformation": "^5.27.1",
         "whatsapp-web.js": "^1.23.0"
@@ -1229,6 +1230,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -2073,6 +2088,36 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "nodejs-whisper": "^0.1.19",
     "ollama": "^0.5.1",
     "p-limit": "^6.2.0",
+    "playwright": "^1.42.0",
     "qrcode-terminal": "^0.12.0",
     "systeminformation": "^5.27.1",
     "whatsapp-web.js": "^1.23.0"

--- a/src/core/whatsAppBot.js
+++ b/src/core/whatsAppBot.js
@@ -361,16 +361,14 @@ class WhatsAppBot {
   }
 
   async handleLinkedinCommand(contactId, text) {
-    this.setMode(contactId, CHAT_MODES.LINKEDIN);
-    const query = text.substring(COMMANDS.LINKEDIN.length).trim();
-    if (!query) {
+    const url = text.substring(COMMANDS.LINKEDIN.length).trim();
+    if (!url) {
       await this.sendResponse(contactId, MODE_MESSAGES[CHAT_MODES.LINKEDIN]);
       return;
     }
-    await this.sendResponse(contactId, '💼 Analisando perfil...', true); // Status sempre em texto
-    const response = await this.llmService.getAssistantResponseLinkedin(contactId, `Analisar perfil: ${query}`);
+    await this.sendResponse(contactId, '💼 Analisando perfil...', true);
+    const response = await this.llmService.getAssistantResponseLinkedin(contactId, url);
     await this.sendResponse(contactId, response);
-    this.setMode(contactId, null);
   }
 
   async handleListarCommand(contactId) {

--- a/src/services/linkedinScraper.js
+++ b/src/services/linkedinScraper.js
@@ -1,0 +1,20 @@
+import { chromium } from 'playwright';
+
+export async function scrapeProfile(url) {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle').catch(() => {});
+    const name = await page.$eval('h1', el => el.textContent.trim());
+    const headline = await page.$eval('[data-field="headline"], .text-body-medium', el => el.textContent.trim()).catch(() => null);
+    const about = await page.$eval('#about ~ div p', el => el.textContent.trim()).catch(() => null);
+    const experiences = await page.$$eval('#experience ~ ul li, section[id*=experience] li', els => els.map(e => e.innerText.trim()));
+    const education = await page.$$eval('#education ~ ul li, section[id*=education] li', els => els.map(e => e.innerText.trim()));
+    return { url, name, headline, about, experiences, education };
+  } catch (err) {
+    throw new Error(`Scraping failed: ${err.message}`);
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -1,6 +1,7 @@
 import ollama from 'ollama';
 import Utils from '../utils/index.js'; // Ajustar caminho se necessário
 import { CONFIG, CHAT_MODES, PROMPTS } from '../config/index.js'; // Ajustar caminho se necessário
+import { scrapeProfile } from './linkedinScraper.js';
 
 // ============ Serviço LLM ============
 class LLMService {
@@ -55,11 +56,15 @@ class LLMService {
     return this.chat(contactId, text, CHAT_MODES.ASSISTANT, PROMPTS.assistant(date));
   }
 
-  async getAssistantResponseLinkedin(contactId, text) {
-    // Simulação, idealmente buscaria dados reais do LinkedIn
-    const linkedinJson = { profileData: text }; // Exemplo, usar dados reais
-    const jsonText = JSON.stringify(linkedinJson, null, 2);
-    return this.chat(contactId, jsonText, CHAT_MODES.LINKEDIN, PROMPTS.linkedin);
+  async getAssistantResponseLinkedin(contactId, url) {
+    try {
+      const data = await scrapeProfile(url);
+      const jsonText = JSON.stringify(data, null, 2);
+      return await this.chat(contactId, jsonText, CHAT_MODES.LINKEDIN, PROMPTS.linkedin);
+    } catch (err) {
+      console.error('Erro ao raspar LinkedIn:', err);
+      return 'Função em construção.';
+    }
   }
 
   clearContext(contactId, type) {


### PR DESCRIPTION
## Summary
- install Playwright
- add a Playwright-based LinkedIn scraper service
- integrate scraper in `llmService`
- update WhatsApp bot command to accept `!linkedin <URL>`
- document the new command and Playwright setup in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684124664fb8832c9a822bb13025e04e