### PR TITLE
Improve dashboard

### DIFF
--- a/src/api/restApi.js
+++ b/src/api/restApi.js
@@ -67,8 +67,22 @@ class RestAPI {
     });
 
     // Rota para um Dashboard simples em HTML
-    this.app.get('/dashboard', (req, res) => {
+    this.app.get('/dashboard', async (req, res) => {
       const uptimeMinutes = Math.floor(process.uptime() / 60);
+      let stats = {
+        total: 0,
+        pending: 0,
+        sent: 0,
+        failed: 0,
+        upcoming: []
+      };
+      try {
+        if (this.bot.getScheduler) {
+          stats = await this.bot.getScheduler().getStats();
+        }
+      } catch (err) {
+        console.error('❌ Erro ao coletar estatísticas para o dashboard:', err);
+      }
       const html = `
         <!DOCTYPE html>
         <html lang="pt-BR">
@@ -97,6 +111,18 @@ class RestAPI {
               <p><strong>Bot Uptime:</strong> ${uptimeMinutes} minutos</p>
               <p><strong>Timestamp:</strong> ${new Date().toLocaleString('pt-BR')}</p>
             </div>
+            <h2>📊 Estatísticas de Agendamentos</h2>
+            <p>Total: ${stats.total}</p>
+            <p>Pendentes: ${stats.pending}</p>
+            <p>Enviados: ${stats.sent}</p>
+            <p>Falhos: ${stats.failed}</p>
+            <h3>Próximos 5 Agendamentos</h3>
+            <ul class="commands-list">
+              ${stats.upcoming.map(item =>
+                `<li>${new Date(item.scheduledTime).toLocaleString('pt-BR')} - ${item.message}</li>`
+              ).join('') || '<li>Nenhum agendamento</li>'}
+            </ul>
+
             <h2>📋 Comandos Disponíveis no Bot</h2>
             <ul class="commands-list">
               ${Object.entries(COMMANDS).map(([key, cmd]) =>

--- a/src/core/whatsAppBot.js
+++ b/src/core/whatsAppBot.js
@@ -48,6 +48,10 @@ class WhatsAppBot {
     return this.client;
   }
 
+  getScheduler() {
+    return this.scheduler;
+  }
+
   // --- Métodos de Preferência do Usuário ---
   getUserPreference(contactId, key, defaultValue = false) {
     const prefs = this.userPreferences.get(contactId) || {};


### PR DESCRIPTION
## Summary
- add stats retrieval method to scheduler
- expose scheduler getter from WhatsAppBot
- expand dashboard page with scheduling stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841cfa20d48832c98e9ce9d26b3d2f4