### PR TITLE
Implement memory-aware job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Os principais comandos podem ser vistos no menu do aplicativo ou acessando o das
    PIPER_MODEL=/caminho/para/modelo.onnx
    # Caso o executável não esteja no PATH, informe também:
    PIPER_EXECUTABLE=/usr/local/bin/piper
+   # Limite de memória em GB para processar tarefas pesadas
+   QUEUE_MEM_THRESHOLD_GB=4
    ```
 
 ### TTS local com Piper

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -30,7 +30,9 @@ const CONFIG = {
   },
   queues: {
     llmConcurrency: parseInt(process.env.LLM_CONCURRENCY || '2', 10),
-    whisperConcurrency: parseInt(process.env.WHISPER_CONCURRENCY || '1', 10)
+    whisperConcurrency: parseInt(process.env.WHISPER_CONCURRENCY || '1', 10),
+    memoryThresholdGB: parseInt(process.env.QUEUE_MEM_THRESHOLD_GB || '4', 10),
+    memoryCheckInterval: parseInt(process.env.MEM_CHECK_INTERVAL || '1000', 10)
   },
   llm: {
     model: 'granite3.2:latest',

--- a/src/services/audioTranscriber.js
+++ b/src/services/audioTranscriber.js
@@ -10,7 +10,10 @@ import JobQueue from './jobQueue.js';
 // ============ Transcritor de Áudio ============
 class AudioTranscriber {
   constructor() {
-    this.queue = new JobQueue(CONFIG.queues.whisperConcurrency);
+    this.queue = new JobQueue(
+      CONFIG.queues.whisperConcurrency,
+      CONFIG.queues.memoryThresholdGB
+    );
   }
 
   async transcribe(audioBuffer) {

--- a/src/services/jobQueue.js
+++ b/src/services/jobQueue.js
@@ -1,12 +1,33 @@
 import pLimit from 'p-limit';
+import si from 'systeminformation';
+import { CONFIG } from '../config/index.js';
 
 class JobQueue {
-  constructor(concurrency = 1) {
+  constructor(concurrency = 1, memoryThresholdGB = 0) {
     this.limit = pLimit(concurrency);
+    this.memoryThreshold = memoryThresholdGB > 0 ? memoryThresholdGB * 1024 * 1024 * 1024 : 0;
+  }
+
+  async waitForMemory() {
+    if (!this.memoryThreshold) return;
+    while (true) {
+      try {
+        const mem = await si.mem();
+        const used = mem.total - mem.available;
+        if (used < this.memoryThreshold) break;
+      } catch (err) {
+        console.error('Erro ao verificar memória:', err);
+        break;
+      }
+      await new Promise(res => setTimeout(res, CONFIG.queues.memoryCheckInterval));
+    }
   }
 
   add(task) {
-    return this.limit(task);
+    return this.limit(async () => {
+      await this.waitForMemory();
+      return task();
+    });
   }
 }
 

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -8,7 +8,10 @@ import JobQueue from './jobQueue.js';
 class LLMService {
   constructor() {
     this.contexts = new Map();
-    this.queue = new JobQueue(CONFIG.queues.llmConcurrency);
+    this.queue = new JobQueue(
+      CONFIG.queues.llmConcurrency,
+      CONFIG.queues.memoryThresholdGB
+    );
   }
 
   getContext(contactId, type) {


### PR DESCRIPTION
## Summary
- add memory threshold fields to config
- implement memory-aware waiting in JobQueue
- apply memory threshold for LLM and Whisper tasks
- document QUEUE_MEM_THRESHOLD_GB variable

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684205ae3a24832c8de372385a0d2e2a