### PR TITLE
Improve dashboard access and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Após iniciar, envie `!menu` ou os atalhos numéricos para ver as opções. Entr
 - `!linkedin <URL>` para resumir dados públicos de um perfil
 - `!resumir` com texto ou arquivo (PDF, TXT, DOCX ou CSV) para resumir o conteúdo
 
-A interface web de agendamento pode ser acessada em `/`. Ela permite listar, criar, editar e duplicar lembretes usando um formulário simples e exibe estatísticas do bot.
+Ao iniciar o bot você terá acesso a uma pequena interface web. Na página inicial (`/`) há um menu de painéis que inclui o dashboard de agendamentos e a tela de configurações. O dashboard propriamente dito está em `/dashboard` e permite listar, criar, editar e duplicar lembretes, além de exibir estatísticas do bot.
+As configurações da aplicação ficam em `/config`. Após salvar o formulário todas as variáveis são gravadas no `.env` e a aplicação é reiniciada automaticamente para aplicar os novos valores.
 
 
 ## Estrutura da Base (MongoDB)
@@ -199,5 +200,11 @@ Os testes unitários são executados durante a fase de build. Após a conclusão
 
 ```bash
 docker run -p 3000:3000 secrebot
+```
+
+Para facilitar a execução com todas as dependências (MongoDB e Ollama) utilize o `docker-compose.yml` incluido no repositório:
+
+```bash
+docker compose up --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  bot:
+    build: .
+    container_name: secrebot
+    environment:
+      - MONGO_URI=mongodb://mongodb:27017/
+      - PORT=3000
+      - OLLAMA_HOST=http://ollama:11434
+      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
+      - ELEVENLABS_VOICE_ID=${ELEVENLABS_VOICE_ID}
+    volumes:
+      - ./.env:/app/.env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongodb
+      - ollama
+  mongodb:
+    image: mongo:6
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+volumes:
+  mongo-data:
+  ollama-data:

--- a/src/api/restApi.js
+++ b/src/api/restApi.js
@@ -88,7 +88,13 @@ class RestAPI {
     // ===== Scheduler UI Routes =====
     const schedCollection = this.bot.getScheduler().schedCollection;
 
-    this.app.get('/', async (req, res) => {
+    // Página inicial com menu de dashboards
+    this.app.get('/', (req, res) => {
+      res.render('home');
+    });
+
+    // Dashboard de agendamentos
+    this.app.get('/dashboard', async (req, res) => {
       const [messages, stats] = await Promise.all([
         schedCollection.find({}).toArray(),
         this.bot.getScheduler().getStats()
@@ -209,7 +215,9 @@ class RestAPI {
       fs.writeFileSync(envPath, lines);
       dotenv.config({ path: envPath, override: true });
       updateConfigFromEnv();
-      res.redirect('/config');
+      res.send('Configurações salvas. Reiniciando...');
+      console.log('♻️  Reiniciando aplicação para aplicar novas configurações');
+      setTimeout(() => process.exit(0), 500);
     });
 
     // Rota catch-all para 404

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -1,0 +1,9 @@
+<h1 class="mb-4">Painéis Disponíveis</h1>
+<ul class="list-group">
+  <li class="list-group-item">
+    <a href="/dashboard">Agendamentos</a>
+  </li>
+  <li class="list-group-item">
+    <a href="/config">Configurações</a>
+  </li>
+</ul>

--- a/src/views/layout.ejs
+++ b/src/views/layout.ejs
@@ -18,6 +18,15 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
+          <a class="nav-link" href="/">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/dashboard">Dashboard</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/config">Configurações</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="/messages/new">Adicionar Mensagem</a>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- create a home page that links to dashboards
- add navigation menu entries
- show dashboard at `/dashboard`
- restart the app automatically after editing config
- provide docker-compose with MongoDB and Ollama
- document the new UI behaviour and compose usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684399a603bc832c927e87f0b91bd874