### PR TITLE
Ajusta timeout do LLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ SCHED_MAX_CONCURRENCY=10
 SCHED_CPU_THRESHOLD=0.7
 SCHED_MEM_THRESHOLD=0.8
 OLLAMA_HOST=http://127.0.0.1:11434
+# tempo máximo para receber os headers do Ollama (ms)
 OLLAMA_TIMEOUT_MS=60000
 CALORIE_API_URL=https://api.api-ninjas.com/v1/nutrition?query=
 CALORIE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -98,15 +98,16 @@ Os principais comandos podem ser vistos no menu do aplicativo ou acessando a int
    DYNAMIC_CONCURRENCY=false
    SCHED_MAX_CONCURRENCY=10
    SCHED_CPU_THRESHOLD=0.7
-   SCHED_MEM_THRESHOLD=0.8
-   OLLAMA_HOST=http://127.0.0.1:11434
-   OLLAMA_TIMEOUT_MS=60000
+  SCHED_MEM_THRESHOLD=0.8
+  OLLAMA_HOST=http://127.0.0.1:11434
+  OLLAMA_TIMEOUT_MS=60000  # tempo máximo para resposta inicial do modelo
   CALORIE_API_URL=https://api.api-ninjas.com/v1/nutrition?query=
   CALORIE_API_KEY=
   LINKEDIN_USER=
   LINKEDIN_PASS=
   LINKEDIN_LI_AT=
   LINKEDIN_TIMEOUT_MS=30000
+  # aumente OLLAMA_TIMEOUT_MS caso ocorra "Headers Timeout" ao contactar o LLM
   # Integração com Google Calendar
    GOOGLE_CLIENT_ID=
    GOOGLE_CLIENT_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       - MONGO_URI=mongodb://mongodb:27017/
       - PORT=3000
       - OLLAMA_HOST=http://ollama:11434
-      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
+      # aumenta o timeout do Undici para aguardar o carregamento do modelo
+      - OLLAMA_TIMEOUT_MS=120000
+    - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
       - ELEVENLABS_VOICE_ID=${ELEVENLABS_VOICE_ID}
     volumes:
       - ./.env:/app/.env

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,8 +6,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config();
 
 // Aumenta o tempo limite do Undici caso especificado
+// Ajusta os timeouts do Undici se OLLAMA_TIMEOUT_MS estiver definido
 if (process.env.OLLAMA_TIMEOUT_MS) {
   process.env.UNDICI_HEADERS_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
+  process.env.UNDICI_BODY_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
 }
 
 const OLLAMA_HOST = process.env.OLLAMA_HOST || 'http://127.0.0.1:11434';
@@ -315,6 +317,7 @@ function updateConfigFromEnv() {
   CONFIG.llm.host = process.env.OLLAMA_HOST || CONFIG.llm.host;
   if (process.env.OLLAMA_TIMEOUT_MS) {
     process.env.UNDICI_HEADERS_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
+    process.env.UNDICI_BODY_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
   }
 
   CONFIG.elevenlabs.apiKey = process.env.ELEVENLABS_API_KEY || CONFIG.elevenlabs.apiKey;


### PR DESCRIPTION
## Summary
- document `OLLAMA_TIMEOUT_MS` and use it to set `UNDICI_BODY_TIMEOUT`
- add example in docker-compose

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843affdb440832cbac411358168bdb1