### PR TITLE
Add auto login retry for LinkedIn scraper

### DIFF
--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -1,7 +1,11 @@
 import { Ollama } from 'ollama';
 import Utils from '../utils/index.js'; // Ajustar caminho se necessário
 import { CONFIG, CHAT_MODES, PROMPTS } from '../config/index.js'; // Ajustar caminho se necessário
-import { scrapeProfile, loginAndGetLiAt } from './linkedinScraper.js';
+import {
+  scrapeProfile,
+  loginAndGetLiAt,
+  scrapeProfileWithAutoLogin
+} from './linkedinScraper.js';
 import JobQueue from './jobQueue.js';
 
 // ============ Serviço LLM ============
@@ -66,7 +70,12 @@ class LLMService {
 
   async getAssistantResponseLinkedin(contactId, url, liAt) {
     try {
-      const data = await scrapeProfile(url, { liAt, timeoutMs: CONFIG.linkedin.timeoutMs });
+      const data = await scrapeProfileWithAutoLogin(url, {
+        liAt,
+        timeoutMs: CONFIG.linkedin.timeoutMs,
+        user: CONFIG.linkedin.user,
+        pass: CONFIG.linkedin.pass
+      });
       const jsonText = JSON.stringify(data, null, 2);
       return await this.chat(contactId, jsonText, CHAT_MODES.LINKEDIN, PROMPTS.linkedin);
     } catch (err) {

--- a/test/linkedinScraper.test.js
+++ b/test/linkedinScraper.test.js
@@ -1,6 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { scrapeProfile, loginAndGetLiAt } from '../src/services/linkedinScraper.js';
+import {
+  scrapeProfile,
+  loginAndGetLiAt,
+  scrapeProfileWithAutoLogin
+} from '../src/services/linkedinScraper.js';
 
 // These tests use short timeouts to avoid long waits in CI.
 
@@ -12,4 +16,39 @@ test('scrapeProfile fails for invalid URL', async () => {
 test('loginAndGetLiAt returns null for bad credentials', async () => {
   const cookie = await loginAndGetLiAt('fake', 'fake', 1000).catch(() => null);
   assert.equal(cookie, null);
+});
+
+test('scrapeProfileWithAutoLogin triggers login on invalid cookie', async () => {
+  let loginCalled = false;
+  const stubScrape = async (url, opts) => {
+    if (!loginCalled) {
+      return { success: false, error: 'Too Many Redirects' };
+    }
+    return { success: true };
+  };
+  const stubLogin = async () => {
+    loginCalled = true;
+    return 'newCookie';
+  };
+  const res = await scrapeProfileWithAutoLogin('https://linkedin.com', {
+    liAt: 'bad',
+    user: 'user',
+    pass: 'pass',
+    scrapeFn: stubScrape,
+    loginFn: stubLogin,
+    timeoutMs: 1000
+  });
+  assert.equal(loginCalled, true);
+  assert.equal(res.success, true);
+  assert.equal(res.newLiAt, 'newCookie');
+});
+
+test('scrapeProfileWithAutoLogin returns result when no credentials', async () => {
+  const stubScrape = async () => ({ success: false, error: 'Too Many Requests' });
+  const res = await scrapeProfileWithAutoLogin('https://linkedin.com', {
+    liAt: 'bad',
+    scrapeFn: stubScrape,
+    timeoutMs: 1000
+  });
+  assert.equal(res.success, false);
 });


### PR DESCRIPTION
## Summary
- enhance LinkedIn scraper to retry by logging in when cookie is invalid
- use new retry helper in LLM service
- test new behaviour of LinkedIn scraper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843b3b4fb28832caecf282434823aab