### PR TITLE
Fix unused import in TTS service

### DIFF
--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -1,4 +1,4 @@
-import { ElevenLabsClient, stream } from "elevenlabs";
+import { ElevenLabsClient } from "elevenlabs";
 import { CONFIG } from "../config/index.js";
 import fs from 'fs/promises';
 import fsSync from 'fs';


### PR DESCRIPTION
## Summary
- clean up ttsService by removing the unused `stream` import

## Testing
- `npm test` *(fails: Cannot find package 'p-limit', 'playwright', 'mongodb', 'gpt-3-encoder')*

------
https://chatgpt.com/codex/tasks/task_e_6845083384bc832c8630740c0321b645