### PR TITLE
Fix ELEVENLABS env indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - OLLAMA_HOST=http://ollama:11434
       # aumenta o timeout do Undici para aguardar o carregamento do modelo
       - OLLAMA_TIMEOUT_MS=120000
-    - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
+      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
       - ELEVENLABS_VOICE_ID=${ELEVENLABS_VOICE_ID}
     volumes:
       - ./.env:/app/.env


### PR DESCRIPTION
## Summary
- fix indentation for `ELEVENLABS_API_KEY` and `ELEVENLABS_VOICE_ID` in `docker-compose.yml`

## Testing
- `python3 - <<'EOF'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print("YAML OK")
EOF`
- `npm test` *(fails: Cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_6845082dbbf8832c9569df7f77b885b6