### PR TITLE
Add Mongo client disconnect handling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,8 @@ import RestAPI from './api/restApi.js';
 import ConfigService from './services/configService.js';
 import { applyConfig } from './config/index.js';
 
+let scheduler;
+
 // ============ Inicialização ============
 async function main() {
   try {
@@ -22,7 +24,7 @@ async function main() {
 
     // Inicializar serviços
     console.log('📦 Inicializando serviços...');
-    const scheduler = new Scheduler();
+    scheduler = new Scheduler();
     await scheduler.connect(); // Conectar ao MongoDB
 
     const configService = new ConfigService(scheduler.db);
@@ -63,9 +65,11 @@ process.on('uncaughtException', (err) => {
 });
 
 // Tratamento de sinais do sistema para encerramento gracioso
-const gracefulShutdown = (signal) => {
+const gracefulShutdown = async (signal) => {
   console.log(`\n👋 Recebido sinal ${signal}. Encerrando aplicação...`);
-  // Adicionar lógica de encerramento gracioso aqui
+  if (scheduler) {
+    await scheduler.disconnect();
+  }
   console.log('🏁 Aplicação encerrada.');
   process.exit(0);
 };

--- a/src/services/scheduler.js
+++ b/src/services/scheduler.js
@@ -7,6 +7,7 @@ import { CONFIG, ERROR_MESSAGES, SUCCESS_MESSAGES, COMMANDS } from '../config/in
 // ============ Scheduler ============
 class Scheduler {
   constructor() {
+    this.client = null;
     this.db = null;
     this.schedCollection = null;
     this.userSchedules = new Map(); // Cache para deleção
@@ -57,12 +58,10 @@ class Scheduler {
 
   async connect() {
     try {
-      const client = await MongoClient.connect(CONFIG.mongo.uri, {
-        // As opções useNewUrlParser e useUnifiedTopology são depreciadas
-        // O driver moderno as habilita por padrão quando necessário
-      });
+      this.client = new MongoClient(CONFIG.mongo.uri);
+      await this.client.connect();
       console.log('✅ Conectado ao MongoDB.');
-      this.db = client.db(CONFIG.mongo.dbName);
+      this.db = this.client.db(CONFIG.mongo.dbName);
       this.schedCollection = this.db.collection(CONFIG.mongo.collectionName);
 
       // Garantir índices (pode ser feito uma vez na inicialização)
@@ -73,6 +72,14 @@ class Scheduler {
     } catch (err) {
       console.error('❌ Erro ao conectar ao MongoDB:', err);
       throw err;
+    }
+  }
+
+  async disconnect() {
+    if (this.client) {
+      await this.client.close();
+      this.client = null;
+      console.log('🔌 Conexão com MongoDB encerrada.');
     }
   }
 


### PR DESCRIPTION
## Summary
- keep MongoClient instance in scheduler
- provide disconnect method for cleanup
- cleanly shutdown server by awaiting Mongo disconnect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684508356b48832cb8442c69411d6e69