### PR TITLE
Fix command prefix detection

### DIFF
--- a/src/core/whatsAppBot.js
+++ b/src/core/whatsAppBot.js
@@ -139,7 +139,8 @@ class WhatsAppBot {
 
   isMainCommand(text) {
     const lower = text.toLowerCase();
-    return Object.values(COMMANDS).some(cmd => lower.startsWith(cmd));
+    const commands = Object.values(COMMANDS).sort((a, b) => b.length - a.length);
+    return commands.some(cmd => lower.startsWith(cmd));
   }
 
   getCurrentMode(contactId) {
@@ -284,7 +285,8 @@ class WhatsAppBot {
           }
       };
 
-      for (const [command, handler] of Object.entries(commandHandlers)) {
+      const sortedHandlers = Object.entries(commandHandlers).sort((a, b) => b[0].length - a[0].length);
+      for (const [command, handler] of sortedHandlers) {
           if (lowerText.startsWith(command)) {
               console.log(`⚙️ Executando comando ${command} para ${contactId}`);
               await handler();


### PR DESCRIPTION
## Summary
- ensure longer commands get matched before shorter ones
- sort commands by length when checking `isMainCommand`
- sort command handlers by length in `handleCommand`

## Testing
- `npm test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685387372b50832ca3d78fd7d155eea0