### PR TITLE
Add yt-dlp fallback for YouTube audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Os principais comandos podem ser vistos no menu do aplicativo ou acessando a int
 - Conta e chave da [ElevenLabs](https://elevenlabs.io/) para recursos de voz (opcional)
 - [Ollama](https://ollama.ai/) instalado para executar o modelo local de LLM
 - [`Playwright`](https://playwright.dev/) instalado (após `npm install` execute `npx playwright install` para baixar os navegadores)
+- [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) para download de áudio do YouTube (utilizado como fallback quando `ytdl-core` falha)
 
 ## Instalação
 

--- a/src/services/youtubeService.js
+++ b/src/services/youtubeService.js
@@ -3,6 +3,7 @@ import ffmpeg from 'fluent-ffmpeg';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
 import AudioTranscriber from './audioTranscriber.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -12,7 +13,7 @@ const transcriber = new AudioTranscriber();
 
 async function downloadAudioBuffer(youtubeUrl) {
   const outputPath = path.join(__dirname, `audio_${Date.now()}.ogg`);
-  return new Promise((resolve, reject) => {
+  const attemptYtdl = () => new Promise((resolve, reject) => {
     const stream = ytdl(youtubeUrl, { quality: 'highestaudio' });
     ffmpeg(stream)
       .audioBitrate(128)
@@ -32,6 +33,43 @@ async function downloadAudioBuffer(youtubeUrl) {
         reject(err);
       });
   });
+
+  const attemptYtDlp = () => new Promise((resolve, reject) => {
+    const proc = spawn('yt-dlp', [
+      '-f', 'bestaudio[ext=webm]/bestaudio/best',
+      '--no-playlist',
+      '-o', outputPath,
+      youtubeUrl
+    ]);
+    proc.on('error', reject);
+    proc.on('close', async (code) => {
+      if (code !== 0) {
+        await fs.unlink(outputPath).catch(() => {});
+        reject(new Error(`yt-dlp exited with code ${code}`));
+        return;
+      }
+      try {
+        const data = await fs.readFile(outputPath);
+        await fs.unlink(outputPath);
+        resolve(data);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+
+  try {
+    return await attemptYtdl();
+  } catch (err) {
+    if (/Could not extract functions/.test(String(err))) {
+      try {
+        return await attemptYtDlp();
+      } catch (e) {
+        throw e;
+      }
+    }
+    throw err;
+  }
 }
 
 async function fetchTranscript(url) {


### PR DESCRIPTION
## Summary
- implement fallback using `yt-dlp` when `ytdl-core` fails to parse video
- note in README that `yt-dlp` is required for YouTube audio fallback

## Testing
- `npm test`
- `npx playwright install chromium`

------
https://chatgpt.com/codex/tasks/task_e_685388a53948832c8f32861f5e4667b3