### PR TITLE
Improve yt-dlp error reporting

### DIFF
--- a/src/services/youtubeService.js
+++ b/src/services/youtubeService.js
@@ -41,11 +41,18 @@ async function downloadAudioBuffer(youtubeUrl) {
       '-o', outputPath,
       youtubeUrl
     ]);
+
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
     proc.on('error', reject);
     proc.on('close', async (code) => {
       if (code !== 0) {
         await fs.unlink(outputPath).catch(() => {});
-        reject(new Error(`yt-dlp exited with code ${code}`));
+        const msg = stderr.trim() || `yt-dlp exited with code ${code}`;
+        reject(new Error(msg));
         return;
       }
       try {


### PR DESCRIPTION
## Summary
- capture yt-dlp stderr output to show clearer error messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68538e33ac44832c84d7e08b9fa4df67