### PR TITLE
Add yt-dlp integration for transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,15 @@ cd secrebot
 npm install
 npx playwright install
 ```
+### 3. Instale o yt-dlp (aarch64)
+```bash
+sudo apt update
+sudo apt install -y python3-pip
+pip3 install yt-dlp --break-system-packages
+```
 
-### 3. Configure o Whisper
+
+### 4. Configure o Whisper
 ```bash
 # Certifique-se de ter build-essential instalado
 sudo apt install build-essential
@@ -90,7 +97,7 @@ sudo apt install build-essential
 npx nodejs-whisper download
 ```
 
-### 4. Configure o MongoDB
+### 5. Configure o MongoDB
 ```bash
 # Ubuntu/Debian
 sudo apt update
@@ -105,7 +112,7 @@ mongosh
 > exit
 ```
 
-### 5. Instale e configure o Ollama
+### 6. Instale e configure o Ollama
 ```bash
 # Linux/macOS
 curl -L https://ollama.com/install.sh | sh
@@ -185,7 +192,7 @@ PIPER_EXECUTABLE=/usr/local/bin/piper
 docker run --rm -i -v /caminho/para/modelos:/data ghcr.io/rhasspy/piper:latest "$@"
 ```
 
-### 6. Inicie o bot
+### 7. Inicie o bot
 ```bash
 npm start
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,7 @@
         "qrcode-terminal": "^0.12.0",
         "systeminformation": "^5.27.1",
         "whatsapp-web.js": "^1.23.0",
-        "youtubei.js": "^6.0.1",
-        "ytdl-core": "^4.11.5"
+        "youtubei.js": "^6.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -2409,19 +2408,6 @@
         "node": "*"
       }
     },
-    "node_modules/m3u8stream": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
-      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
-      "license": "MIT",
-      "dependencies": {
-        "miniget": "^4.2.2",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mammoth": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.9.1.tgz",
@@ -2580,15 +2566,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/miniget": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
-      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -3298,12 +3275,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -4150,20 +4121,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "license": "MIT",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/zip-stream": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "node-ical": "^0.16.0",
     "multer": "^1.4.5-lts.1",
     "youtubei.js": "^6.0.1",
-    "ytdl-core": "^4.11.5",
     "ejs": "^3.1.9"
   }
 }


### PR DESCRIPTION
## Summary
- add instructions to install yt-dlp on aarch64
- switch YouTube service to use `yt-dlp` for audio and transcripts
- clean up `ytdl-core` usage

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685889a5f998832cbf275a2ad894ba4c