### PR TITLE
Fix YTDlpWrap import

### DIFF
--- a/src/services/video/VideoProcessor.js
+++ b/src/services/video/VideoProcessor.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import {YTDlpWrap} from 'yt-dlp-wrap';
+import YTDlpWrap from 'yt-dlp-wrap';
 import SubtitleProcessor from './SubtitleProcessor.js';
 import TextSummarizer from './TextSummarizer.js';
 import AudioTranscriber from '../audioTranscriber.js';


### PR DESCRIPTION
## Summary
- correct the `yt-dlp-wrap` import to use the default export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685898e564c0832c96e12679cf4fb010