### PR TITLE
Add CPU-aware whisper wrapper

### DIFF
--- a/src/services/whisper-threads.js
+++ b/src/services/whisper-threads.js
@@ -1,0 +1,36 @@
+import os from 'os';
+import { nodewhisper } from 'nodejs-whisper';
+import { CONFIG } from '../config/index.js';
+
+// Detecta número de núcleos de CPU e ajusta variáveis de ambiente
+const cpuCount = os.cpus().length || 1;
+process.env.OMP_NUM_THREADS = String(cpuCount);
+process.env.MKL_NUM_THREADS = String(cpuCount);
+
+/**
+ * Transcreve um arquivo de áudio usando o nodejs-whisper.
+ * @param {string} filePath Caminho para o arquivo de áudio.
+ * @returns {Promise<string>} Texto transcrito.
+ */
+export async function transcribe(filePath) {
+  const start = Date.now();
+  try {
+    console.log(`🎤 Transcrevendo: ${filePath}`);
+    const text = await nodewhisper(filePath, {
+      modelName: CONFIG.audio.model,
+      autoDownloadModelName: CONFIG.audio.model,
+      withCuda: false,
+      removeWavFileAfterTranscription: false,
+      whisperOptions: {
+        outputInText: true,
+        language: CONFIG.audio.language,
+      },
+    });
+    const duration = ((Date.now() - start) / 1000).toFixed(2);
+    console.log(`✅ Transcrição concluída em ${duration}s`);
+    return text.trim();
+  } catch (err) {
+    console.error('❌ Erro na transcrição:', err.message);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add `whisper-threads` helper module to wrap nodejs-whisper and set thread env vars
- dynamically set OMP and MKL threads to number of CPU cores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858cf76cb48832cbd10db6b31161403