### PR TITLE
Add yt-dlp debugging helper

### DIFF
--- a/src/utils/debugYtdlp.js
+++ b/src/utils/debugYtdlp.js
@@ -1,0 +1,75 @@
+import { spawn } from 'child_process';
+import { access } from 'fs/promises';
+
+/**
+ * Execute yt-dlp with verbose output and return stdout as string.
+ * Logs executed command and any stderr output for easier debugging.
+ * @param {string} url - Video URL to query.
+ * @param {string} [binaryPath='yt-dlp'] - Path to the yt-dlp executable.
+ */
+export async function debugGetVideoInfo(url, binaryPath = 'yt-dlp') {
+  try {
+    await access(binaryPath);
+  } catch {
+    console.error(`[debug] yt-dlp binary not found: ${binaryPath}`);
+    throw new Error('yt-dlp not found');
+  }
+
+  return new Promise((resolve, reject) => {
+    const args = [url, '--dump-json', '--verbose'];
+    console.log(`[debug] Executing: ${binaryPath} ${args.join(' ')}`);
+
+    const proc = spawn(binaryPath, args);
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => {
+      const str = data.toString();
+      stdout += str;
+      process.stdout.write(`[debug:stdout] ${str}`);
+    });
+
+    proc.stderr.on('data', (data) => {
+      const str = data.toString();
+      stderr += str;
+      process.stderr.write(`[debug:stderr] ${str}`);
+    });
+
+    proc.on('error', (err) => {
+      console.error('[debug] Failed to start yt-dlp:', err.message);
+      reject(err);
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        try {
+          const info = JSON.parse(stdout);
+          resolve(info);
+        } catch (e) {
+          reject(e);
+        }
+      } else {
+        const err = new Error(`yt-dlp exited with code ${code}`);
+        err.stderr = stderr;
+        reject(err);
+      }
+    });
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [url, binary] = process.argv.slice(2);
+  if (!url) {
+    console.error('Usage: node debugYtdlp.js <url> [yt-dlp path]');
+    process.exit(1);
+  }
+  debugGetVideoInfo(url, binary).then(
+    (info) => {
+      console.log('\n[debug] Title:', info.title);
+    },
+    (err) => {
+      console.error('[debug] Error:', err);
+      process.exit(1);
+    },
+  );
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { encode } from 'gpt-3-encoder';
 import { CONFIG, COMMANDS } from '../config/index.js'; // Ajustar caminho se necessário
+import { debugGetVideoInfo } from './debugYtdlp.js';
 
 // ============ Classe de Utilitários ============
 class Utils {
@@ -88,6 +89,11 @@ class Utils {
     return lower === COMMANDS.VOLTAR || lower === '0' || lower === 'voltar';
   }
 
+  static async debugGetVideoInfo(url, binaryPath = 'yt-dlp') {
+    return debugGetVideoInfo(url, binaryPath);
+  }
+
 }
 
 export default Utils;
+export { debugGetVideoInfo } from './debugYtdlp.js';


### PR DESCRIPTION
## Summary
- add a utility to run `yt-dlp` with verbose output
- expose `debugGetVideoInfo` via `Utils`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859fa22d3e0832cba57118c130decb5