### PR TITLE
Move config from .env to MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,52 +128,11 @@ ollama serve
 
 ## ⚙️ Configuração
 
-### Variáveis de Ambiente
-Crie um arquivo `.env` na raiz do projeto:
-
-```bash
-# 🔧 Configurações Básicas
-PORT=3000
-MONGO_URI=mongodb://bot:senha@localhost:27017/sched
-
-# 🤖 Ollama/LLM
-OLLAMA_HOST=http://127.0.0.1:11434
-OLLAMA_TIMEOUT_MS=60000
-LLM_CONCURRENCY=2
-
-# 🎤 Audio/TTS
-ELEVENLABS_API_KEY=<sua_chave_elevenlabs>
-ELEVENLABS_VOICE_ID=<voice_id>
-
-# 🎯 TTS Local (Piper) - Opcional
-PIPER_MODEL=/caminho/para/modelo.onnx
-PIPER_EXECUTABLE=/usr/local/bin/piper
-
-# 🧠 Processamento
-WHISPER_CONCURRENCY=1
-QUEUE_MEM_THRESHOLD_GB=4
-DYNAMIC_CONCURRENCY=false
-# Intervalo para checar novos vídeos (ms)
-FEED_CHECK_INTERVAL=1800000
-
-# 📅 Agendamentos
-SCHED_MAX_CONCURRENCY=10
-SCHED_CPU_THRESHOLD=0.7
-SCHED_MEM_THRESHOLD=0.8
-
-# 🔗 Integrações Externas
-CALORIE_API_URL=https://api.api-ninjas.com/v1/nutrition?query=
-CALORIE_API_KEY=<sua_chave_ninjas>
-LINKEDIN_USER=<seu_usuario>
-LINKEDIN_PASS=<sua_senha>
-LINKEDIN_LI_AT=<cookie_li_at>
-LINKEDIN_TIMEOUT_MS=30000
-
-# 📅 Google Calendar
-GOOGLE_CLIENT_ID=<client_id>
-GOOGLE_CLIENT_SECRET=<client_secret>
-GOOGLE_REDIRECT=http://localhost:3000/oauth2callback
-```
+### Armazenamento de Configurações
+Todas as opções de funcionamento são persistidas na coleção `config` do MongoDB.
+Ao iniciar o bot pela primeira vez, esse documento é criado com valores padrão.
+Acesse a rota `/config` na interface web para ajustar as preferências de acordo
+com o seu ambiente.
 
 ### 🗣️ TTS Local com Piper
 
@@ -183,7 +142,7 @@ Para usar TTS local sem depender da ElevenLabs:
 # Instale o Piper
 # Baixe um modelo pt-br de https://github.com/rhasspy/piper
 
-# Configure no .env
+# Defina estes caminhos em `/config`
 PIPER_ENABLED=true
 PIPER_MODEL=/caminho/para/pt-br-voce.onnx
 PIPER_EXECUTABLE=/usr/local/bin/piper
@@ -311,7 +270,7 @@ DELETE /api/feeds/UCxxxx?phone=5511999999999
 ### ⚙️ Configurações
 - **Rota**: `/config`
 - **Recursos**:
-  - Edição de variáveis do `.env`
+  - Edição das configurações salvas no MongoDB
   - Reinicialização automática
   - Validação de configurações
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,94 +1,85 @@
-import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config();
-
-// Aumenta o tempo limite do Undici caso especificado
-// Ajusta os timeouts do Undici se OLLAMA_TIMEOUT_MS estiver definido
-if (process.env.OLLAMA_TIMEOUT_MS) {
-  process.env.UNDICI_HEADERS_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-  process.env.UNDICI_BODY_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-}
-
-const OLLAMA_HOST = process.env.OLLAMA_HOST;
+const OLLAMA_HOST = 'http://127.0.0.1:11434';
 
 // ===================== CONFIGURAÇÕES =====================
 const CONFIG = {
   mongo: {
-    uri: process.env.MONGO_URI || 'mongodb://admin:admin@127.0.0.1:27017/',
+    uri: 'mongodb://admin:admin@127.0.0.1:27017/',
     dbName: 'sched',
     collectionName: 'schedv2'
   },
   server: {
-    port: process.env.PORT || 3000
+    port: 3000
   },
   scheduler: {
-    interval: parseInt(process.env.SCHED_INTERVAL || '30000', 10),
-    maxAttempts: parseInt(process.env.SCHED_MAX_ATTEMPTS || '3', 10),
-    retryDelay: parseInt(process.env.SCHED_RETRY_DELAY || String(2 * 60 * 60 * 1000), 10),
-    concurrency: parseInt(process.env.SCHED_CONCURRENCY || '5', 10),
+    interval: 30000,
+    maxAttempts: 3,
+    retryDelay: 2 * 60 * 60 * 1000,
+    concurrency: 5,
     dynamic: {
-      enabled: process.env.DYNAMIC_CONCURRENCY === 'true',
-      min: parseInt(process.env.SCHED_DYNAMIC_MIN || '1', 10),
-      max: parseInt(process.env.SCHED_MAX_CONCURRENCY || '10', 10),
-      cpuThreshold: parseFloat(process.env.SCHED_CPU_THRESHOLD || '0.7'),
-      memThreshold: parseFloat(process.env.SCHED_MEM_THRESHOLD || '0.8')
+      enabled: false,
+      min: 1,
+      max: 10,
+      cpuThreshold: 0.7,
+      memThreshold: 0.8
     }
   },
   queues: {
-    llmConcurrency: parseInt(process.env.LLM_CONCURRENCY || '2', 10),
-    whisperConcurrency: parseInt(process.env.WHISPER_CONCURRENCY || '1', 10),
-    memoryThresholdGB: parseInt(process.env.QUEUE_MEM_THRESHOLD_GB || '4', 10),
-    memoryCheckInterval: parseInt(process.env.MEM_CHECK_INTERVAL || '1000', 10)
+    llmConcurrency: 2,
+    whisperConcurrency: 1,
+    memoryThresholdGB: 4,
+    memoryCheckInterval: 1000
   },
   feeds: {
-    checkInterval: parseInt(process.env.FEED_CHECK_INTERVAL || String(30 * 60 * 1000), 10)
+    checkInterval: 30 * 60 * 1000
   },
   video: {
-    ytdlpPath: process.env.YTDLP_PATH || '/usr/bin/yt-dlp'
+    ytdlpPath: '/usr/bin/yt-dlp',
+    maxBufferMb: 10
   },
   llm: {
-    model: process.env.LLM_MODEL || 'granite3.2:latest',
-    imageModel: process.env.LLM_IMAGE_MODEL || 'llava:7b',
-    maxTokens: parseInt(process.env.LLM_MAX_TOKENS || '3000', 10),
+    model: 'granite3.2:latest',
+    imageModel: 'llava:7b',
+    maxTokens: 3000,
     host: OLLAMA_HOST
   },
   audio: {
-    sampleRate: parseInt(process.env.AUDIO_SAMPLE_RATE || '16000', 10),
-    model: process.env.WHISPER_MODEL || 'medium',
-    language: process.env.AUDIO_LANGUAGE || 'pt'
+    sampleRate: 16000,
+    model: 'medium',
+    language: 'pt'
   },
   // Novas configurações para ElevenLabs
   elevenlabs: {
-    apiKey: process.env.ELEVENLABS_API_KEY,
-    voiceId: process.env.ELEVENLABS_VOICE_ID,
-    modelId: process.env.ELEVENLABS_MODEL_ID || 'eleven_multilingual_v2',
-    stability: parseFloat(process.env.ELEVENLABS_STABILITY || '0.5'),
-    similarityBoost: parseFloat(process.env.ELEVENLABS_SIMILARITY || '0.75')
+    apiKey: '',
+    voiceId: '',
+    modelId: 'eleven_multilingual_v2',
+    stability: 0.5,
+    similarityBoost: 0.75
   },
   // Configurações para TTS local usando Piper
   piper: {
-    enabled: process.env.PIPER_ENABLED === 'true' || !!process.env.PIPER_MODEL,
-    executable: process.env.PIPER_EXECUTABLE || 'piper',
-    model: process.env.PIPER_MODEL || ''
+    enabled: false,
+    executable: 'piper',
+    model: ''
   },
   calorieApi: {
-    url: process.env.CALORIE_API_URL || 'https://api.api-ninjas.com/v1/nutrition?query=',
-    key: process.env.CALORIE_API_KEY || ''
+    url: 'https://api.api-ninjas.com/v1/nutrition?query=',
+    key: ''
   },
   google: {
-    clientId: process.env.GOOGLE_CLIENT_ID || '',
-    clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-    redirect: process.env.GOOGLE_REDIRECT || 'http://localhost:3000/oauth2callback'
+    clientId: '',
+    clientSecret: '',
+    redirect: 'http://localhost:3000/oauth2callback'
   },
   // Configurações para login no LinkedIn
   linkedin: {
-    user: process.env.LINKEDIN_USER || '',
-    pass: process.env.LINKEDIN_PASS || '',
-    liAt: process.env.LINKEDIN_LI_AT || '',
-    timeoutMs: parseInt(process.env.LINKEDIN_TIMEOUT_MS || '30000', 10)
+    user: '',
+    pass: '',
+    liAt: '',
+    timeoutMs: 30000
   }
 };
 
@@ -138,49 +129,6 @@ const CONFIG_DESCRIPTIONS = {
   'linkedin.timeoutMs': 'Timeout do LinkedIn (ms)'
 };
 
-const CONFIG_ENV_MAP = {
-  'mongo.uri': 'MONGO_URI',
-  'server.port': 'PORT',
-  'scheduler.interval': 'SCHED_INTERVAL',
-  'scheduler.maxAttempts': 'SCHED_MAX_ATTEMPTS',
-  'scheduler.retryDelay': 'SCHED_RETRY_DELAY',
-  'scheduler.concurrency': 'SCHED_CONCURRENCY',
-  'scheduler.dynamic.enabled': 'DYNAMIC_CONCURRENCY',
-  'scheduler.dynamic.min': 'SCHED_DYNAMIC_MIN',
-  'scheduler.dynamic.max': 'SCHED_MAX_CONCURRENCY',
-  'scheduler.dynamic.cpuThreshold': 'SCHED_CPU_THRESHOLD',
-  'scheduler.dynamic.memThreshold': 'SCHED_MEM_THRESHOLD',
-  'queues.llmConcurrency': 'LLM_CONCURRENCY',
-  'queues.whisperConcurrency': 'WHISPER_CONCURRENCY',
-  'queues.memoryThresholdGB': 'QUEUE_MEM_THRESHOLD_GB',
-  'queues.memoryCheckInterval': 'MEM_CHECK_INTERVAL',
-  'feeds.checkInterval': 'FEED_CHECK_INTERVAL',
-  'llm.model': 'LLM_MODEL',
-  'llm.imageModel': 'LLM_IMAGE_MODEL',
-  'llm.maxTokens': 'LLM_MAX_TOKENS',
-  'llm.host': 'OLLAMA_HOST',
-  'audio.sampleRate': 'AUDIO_SAMPLE_RATE',
-  'audio.model': 'WHISPER_MODEL',
-  'audio.language': 'AUDIO_LANGUAGE',
-  'elevenlabs.apiKey': 'ELEVENLABS_API_KEY',
-  'elevenlabs.voiceId': 'ELEVENLABS_VOICE_ID',
-  'elevenlabs.modelId': 'ELEVENLABS_MODEL_ID',
-  'elevenlabs.stability': 'ELEVENLABS_STABILITY',
-  'elevenlabs.similarityBoost': 'ELEVENLABS_SIMILARITY',
-  'piper.enabled': 'PIPER_ENABLED',
-  'piper.executable': 'PIPER_EXECUTABLE',
-  'piper.model': 'PIPER_MODEL',
-  'calorieApi.url': 'CALORIE_API_URL',
-  'calorieApi.key': 'CALORIE_API_KEY',
-  'video.ytdlpPath': 'YTDLP_PATH',
-  'google.clientId': 'GOOGLE_CLIENT_ID',
-  'google.clientSecret': 'GOOGLE_CLIENT_SECRET',
-  'google.redirect': 'GOOGLE_REDIRECT',
-  'linkedin.user': 'LINKEDIN_USER',
-  'linkedin.pass': 'LINKEDIN_PASS',
-  'linkedin.liAt': 'LINKEDIN_LI_AT',
-  'linkedin.timeoutMs': 'LINKEDIN_TIMEOUT_MS'
-};
 
 // ===================== CONSTANTES =====================
 const COMMANDS = {
@@ -356,64 +304,6 @@ Data atual: ${date}.
 };
 
 
-function updateConfigFromEnv() {
-  CONFIG.mongo.uri = process.env.MONGO_URI || CONFIG.mongo.uri;
-  CONFIG.server.port = process.env.PORT || CONFIG.server.port;
-
-  CONFIG.scheduler.interval = parseInt(process.env.SCHED_INTERVAL || CONFIG.scheduler.interval, 10);
-  CONFIG.scheduler.maxAttempts = parseInt(process.env.SCHED_MAX_ATTEMPTS || CONFIG.scheduler.maxAttempts, 10);
-  CONFIG.scheduler.retryDelay = parseInt(process.env.SCHED_RETRY_DELAY || CONFIG.scheduler.retryDelay, 10);
-  CONFIG.scheduler.concurrency = parseInt(process.env.SCHED_CONCURRENCY || CONFIG.scheduler.concurrency, 10);
-
-  CONFIG.scheduler.dynamic.enabled = process.env.DYNAMIC_CONCURRENCY === 'true' || CONFIG.scheduler.dynamic.enabled;
-  CONFIG.scheduler.dynamic.min = parseInt(process.env.SCHED_DYNAMIC_MIN || CONFIG.scheduler.dynamic.min, 10);
-  CONFIG.scheduler.dynamic.max = parseInt(process.env.SCHED_MAX_CONCURRENCY || CONFIG.scheduler.dynamic.max, 10);
-  CONFIG.scheduler.dynamic.cpuThreshold = parseFloat(process.env.SCHED_CPU_THRESHOLD || CONFIG.scheduler.dynamic.cpuThreshold);
-  CONFIG.scheduler.dynamic.memThreshold = parseFloat(process.env.SCHED_MEM_THRESHOLD || CONFIG.scheduler.dynamic.memThreshold);
-
-  CONFIG.queues.llmConcurrency = parseInt(process.env.LLM_CONCURRENCY || CONFIG.queues.llmConcurrency, 10);
-  CONFIG.queues.whisperConcurrency = parseInt(process.env.WHISPER_CONCURRENCY || CONFIG.queues.whisperConcurrency, 10);
-  CONFIG.queues.memoryThresholdGB = parseInt(process.env.QUEUE_MEM_THRESHOLD_GB || CONFIG.queues.memoryThresholdGB, 10);
-  CONFIG.queues.memoryCheckInterval = parseInt(process.env.MEM_CHECK_INTERVAL || CONFIG.queues.memoryCheckInterval, 10);
-  CONFIG.feeds.checkInterval = parseInt(process.env.FEED_CHECK_INTERVAL || CONFIG.feeds.checkInterval, 10);
-
-  CONFIG.audio.sampleRate = parseInt(process.env.AUDIO_SAMPLE_RATE || CONFIG.audio.sampleRate, 10);
-  CONFIG.audio.model = process.env.WHISPER_MODEL || CONFIG.audio.model;
-  CONFIG.audio.language = process.env.AUDIO_LANGUAGE || CONFIG.audio.language;
-
-  CONFIG.llm.model = process.env.LLM_MODEL || CONFIG.llm.model;
-  CONFIG.llm.imageModel = process.env.LLM_IMAGE_MODEL || CONFIG.llm.imageModel;
-  CONFIG.llm.maxTokens = parseInt(process.env.LLM_MAX_TOKENS || CONFIG.llm.maxTokens, 10);
-  CONFIG.llm.host = process.env.OLLAMA_HOST || CONFIG.llm.host;
-  if (process.env.OLLAMA_TIMEOUT_MS) {
-    process.env.UNDICI_HEADERS_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-    process.env.UNDICI_BODY_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-  }
-
-  CONFIG.elevenlabs.apiKey = process.env.ELEVENLABS_API_KEY || CONFIG.elevenlabs.apiKey;
-  CONFIG.elevenlabs.voiceId = process.env.ELEVENLABS_VOICE_ID || CONFIG.elevenlabs.voiceId;
-  CONFIG.elevenlabs.modelId = process.env.ELEVENLABS_MODEL_ID || CONFIG.elevenlabs.modelId;
-  CONFIG.elevenlabs.stability = parseFloat(process.env.ELEVENLABS_STABILITY || CONFIG.elevenlabs.stability);
-  CONFIG.elevenlabs.similarityBoost = parseFloat(process.env.ELEVENLABS_SIMILARITY || CONFIG.elevenlabs.similarityBoost);
-
-  CONFIG.piper.enabled = process.env.PIPER_ENABLED === 'true' || !!process.env.PIPER_MODEL || CONFIG.piper.enabled;
-  CONFIG.piper.executable = process.env.PIPER_EXECUTABLE || CONFIG.piper.executable;
-  CONFIG.piper.model = process.env.PIPER_MODEL || CONFIG.piper.model;
-
-  CONFIG.calorieApi.url = process.env.CALORIE_API_URL || CONFIG.calorieApi.url;
-  CONFIG.calorieApi.key = process.env.CALORIE_API_KEY || CONFIG.calorieApi.key;
-
-  CONFIG.video.ytdlpPath = process.env.YTDLP_PATH || CONFIG.video.ytdlpPath;
-
-  CONFIG.google.clientId = process.env.GOOGLE_CLIENT_ID || CONFIG.google.clientId;
-  CONFIG.google.clientSecret = process.env.GOOGLE_CLIENT_SECRET || CONFIG.google.clientSecret;
-  CONFIG.google.redirect = process.env.GOOGLE_REDIRECT || CONFIG.google.redirect;
-
-  CONFIG.linkedin.user = process.env.LINKEDIN_USER || CONFIG.linkedin.user;
-  CONFIG.linkedin.pass = process.env.LINKEDIN_PASS || CONFIG.linkedin.pass;
-  CONFIG.linkedin.liAt = process.env.LINKEDIN_LI_AT || CONFIG.linkedin.liAt;
-  CONFIG.linkedin.timeoutMs = parseInt(process.env.LINKEDIN_TIMEOUT_MS || CONFIG.linkedin.timeoutMs, 10);
-}
 
 function applyConfig(obj) {
   const merge = (t, s) => {
@@ -441,8 +331,6 @@ export {
   ERROR_MESSAGES,
   PROMPTS,
   CONFIG_DESCRIPTIONS,
-  CONFIG_ENV_MAP,
   __dirname,
-  updateConfigFromEnv,
   applyConfig
 };

--- a/src/utils/ytdlp.js
+++ b/src/utils/ytdlp.js
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process';
 import { access } from 'fs/promises';
 import { promisify } from 'util';
+import { CONFIG } from '../config/index.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -17,7 +18,7 @@ export async function getVideoInfoCli(url, binaryPath = '/usr/bin/yt-dlp') {
     throw new Error('yt-dlp not found');
   }
 
-  const maxBufferMb = parseInt(process.env.YTDLP_MAX_BUFFER_MB || '10', 10);
+  const maxBufferMb = CONFIG.video.maxBufferMb;
   const { stdout } = await execFileAsync(binaryPath, [url, '--dump-json'], {
     maxBuffer: maxBufferMb * 1024 * 1024
   });

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -1,12 +1,12 @@
 <h2>Configurações da aplicação</h2>
 <form action="/config" method="POST">
-  <% for(const key in env){ %>
+  <% for(const key in config){ %>
     <div class="mb-3">
       <label class="form-label"><%= key %></label>
       <% if (descriptions[key]) { %>
         <small class="form-text text-muted"><%= descriptions[key] %></small>
       <% } %>
-      <input type="text" class="form-control" name="<%= key %>" value="<%= env[key] %>">
+      <input type="text" class="form-control" name="<%= key %>" value="<%= config[key] %>">
     </div>
   <% } %>
   <button type="submit" class="btn btn-primary mt-3">Salvar</button>


### PR DESCRIPTION
## Summary
- stop loading environment variables
- define config defaults directly in code
- expose config via `/config` using Mongo values
- read yt-dlp buffer size from config
- update documentation and config view

## Testing
- `npm test` *(fails: Cannot find package 'yt-dlp-wrap' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685a10c3f854832caa3e7c1513b6dd60