### PR TITLE
Persist deep chat context

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - Conversas alimentadas por LLM local (Ollama)
 - Respostas contextuais e personalizadas
 - Suporte a múltiplos modelos de linguagem
+- Histórico do comando `!deep` armazenado no MongoDB para manter contexto
 
 ### 🎤 **Processamento de Áudio**
 - **Transcrição**: Converte mensagens de voz em texto usando Whisper
@@ -176,7 +177,7 @@ Envie `!menu` ou use os atalhos numéricos:
 | `!agendabot` | 2️⃣ | Criar lembretes personalizados |
 | `!listaragendamentos` | 3️⃣ | Listar agendamentos ativos |
 | `!deletaragendamento` | 4️⃣ | Remover agendamentos |
-| `!deep` | 5️⃣ | Conversar com o chatbot IA |
+| `!deep` | 5️⃣ | Conversar com o chatbot IA (contexto salvo) |
 | `!transcrever` | 6️⃣ | Transcrever mensagens de áudio |
 | `!foto` | 7️⃣ | Descrever imagens enviadas |
 | `!calorias` | 8️⃣ | Estimar calorias de alimentos |

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import FeedMonitor from './services/feedMonitor.js';
 import { applyConfig } from './config/index.js';
 
 let scheduler;
+let llmService;
 
 // ============ Inicialização ============
 async function main() {
@@ -32,7 +33,8 @@ async function main() {
     const dbConfig = await configService.init();
     applyConfig(dbConfig);
 
-    const llmService = new LLMService();
+    llmService = new LLMService();
+    await llmService.connect();
     const transcriber = new AudioTranscriber();
     const ttsService = new TtsService(); // Instanciar o serviço TTS
 
@@ -74,6 +76,9 @@ const gracefulShutdown = async (signal) => {
   console.log(`\n👋 Recebido sinal ${signal}. Encerrando aplicação...`);
   if (scheduler) {
     await scheduler.disconnect();
+  }
+  if (llmService) {
+    await llmService.disconnect();
   }
   console.log('🏁 Aplicação encerrada.');
   process.exit(0);

--- a/test/llmService.test.js
+++ b/test/llmService.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import LLMService from '../src/services/llmService.js';
+import { CHAT_MODES, CONFIG } from '../src/config/index.js';
+
+class FakeCollection {
+  constructor() { this.data = []; }
+  async insertOne(doc) { this.data.push(doc); }
+  find(query) {
+    const arr = this.data.filter(d => d.contactId === query.contactId);
+    return { sort: () => ({ toArray: async () => arr }) };
+  }
+  async deleteMany(query) {
+    this.data = this.data.filter(d => d.contactId !== query.contactId);
+  }
+  async createIndex() {}
+}
+
+test('chat stores messages in Mongo collection', async () => {
+  const svc = new LLMService();
+  svc.collection = new FakeCollection();
+  svc.ollama.chat = async () => ({ message: { content: 'ok' } });
+  await svc.chat('u1', 'hello', CHAT_MODES.ASSISTANT, 'hi');
+  assert.equal(svc.collection.data.length, 2);
+  assert.equal(svc.collection.data[0].role, 'user');
+  assert.equal(svc.collection.data[1].role, 'assistant');
+});
+
+test('chat summarizes when context too long', async () => {
+  const svc = new LLMService();
+  svc.collection = new FakeCollection();
+  svc.ollama.chat = async () => ({ message: { content: 'ok' } });
+  svc.summarizer.summarize = async () => ({ text: 'sum' });
+  CONFIG.llm.maxTokens = 2;
+  await svc.saveMessage('u2', 'user', 'a b c d e');
+  await svc.chat('u2', 'x y z', CHAT_MODES.ASSISTANT, 'hi');
+  assert.equal(svc.collection.data[0].role, 'system');
+  assert.ok(svc.collection.data.some(d => d.content.includes('sum')));
+});


### PR DESCRIPTION
## Summary
- store `!deep` conversation history in Mongo `llmcontexts` database
- load history each turn and summarize when context is too large
- connect/disconnect `LLMService` in the app lifecycle
- document new behaviour in README
- test LLMService context handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a13cf8a98832cab03f757c3ad0cf6