### PR TITLE
Store config in MongoDB and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,21 @@ ollama serve
 
 ## ⚙️ Configuração
 
-### Variáveis de Ambiente
-Crie um arquivo `.env` na raiz do projeto:
+### 1. Inicialize o banco
+Execute o script de criação das coleções:
+
+```bash
+npm run setup
+```
+
+### 2. (Opcional) Importe um `.env`
+Edite o arquivo `.env` (use `.env.example` como modelo) e depois rode:
+
+```bash
+npm run migrate
+```
+
+As variáveis serão gravadas na coleção `config`. O aplicativo não lê o `.env` em tempo de execução.
 
 ```bash
 # 🔧 Configurações Básicas
@@ -308,7 +321,7 @@ DELETE /api/feeds/UCxxxx?phone=5511999999999
 ### ⚙️ Configurações
 - **Rota**: `/config`
 - **Recursos**:
-  - Edição de variáveis do `.env`
+  - Edição das configurações salvas
   - Reinicialização automática
   - Validação de configurações
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/app.js",
     "test": "node --test",
-    "migrate": "node scripts/migrateEnvToMongo.js"
+    "migrate": "node scripts/migrateEnvToMongo.js",
+    "setup": "node scripts/setupDatabase.js"
   },
   "keywords": [
     "whatsapp",

--- a/scripts/setupDatabase.js
+++ b/scripts/setupDatabase.js
@@ -1,0 +1,38 @@
+import { MongoClient } from 'mongodb';
+import { CONFIG } from '../src/config/index.js';
+
+async function ensureCollection(db, name) {
+  const exists = await db.listCollections({ name }).hasNext();
+  if (!exists) {
+    await db.createCollection(name);
+  }
+  return db.collection(name);
+}
+
+async function main() {
+  const client = new MongoClient(CONFIG.mongo.uri);
+  await client.connect();
+  const db = client.db(CONFIG.mongo.dbName);
+
+  const configCol = db.collection('config');
+  if (!(await configCol.findOne({ _id: 'app' }))) {
+    await configCol.insertOne({ _id: 'app', values: CONFIG });
+  }
+
+  const sched = await ensureCollection(db, CONFIG.mongo.collectionName);
+  await sched.createIndex({ recipient: 1, status: 1 });
+  await sched.createIndex({ scheduledTime: 1, status: 1, sentAt: 1 });
+
+  const subs = await ensureCollection(db, 'feedSubscriptions');
+  const items = await ensureCollection(db, 'feedItems');
+  await subs.createIndex({ phone: 1, channelId: 1 }, { unique: true });
+  await items.createIndex({ channelId: 1, published: 1 });
+
+  console.log('Database initialized');
+  await client.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,87 +3,81 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Aumenta o tempo limite do Undici caso especificado
-// Ajusta os timeouts do Undici se OLLAMA_TIMEOUT_MS estiver definido
-if (process.env.OLLAMA_TIMEOUT_MS) {
-  process.env.UNDICI_HEADERS_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-  process.env.UNDICI_BODY_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-}
-
-const OLLAMA_HOST = process.env.OLLAMA_HOST;
+// Valor padrão do host do Ollama
+const OLLAMA_HOST = 'http://127.0.0.1:11434';
 
 // ===================== CONFIGURAÇÕES =====================
 const CONFIG = {
   mongo: {
-    uri: process.env.MONGO_URI || 'mongodb://admin:admin@127.0.0.1:27017/',
+    uri: 'mongodb://admin:admin@127.0.0.1:27017/',
     dbName: 'sched',
     collectionName: 'schedv2'
   },
   server: {
-    port: process.env.PORT || 3000
+    port: 3000
   },
   scheduler: {
-    interval: parseInt(process.env.SCHED_INTERVAL || '30000', 10),
-    maxAttempts: parseInt(process.env.SCHED_MAX_ATTEMPTS || '3', 10),
-    retryDelay: parseInt(process.env.SCHED_RETRY_DELAY || String(2 * 60 * 60 * 1000), 10),
-    concurrency: parseInt(process.env.SCHED_CONCURRENCY || '5', 10),
+    interval: 30000,
+    maxAttempts: 3,
+    retryDelay: 2 * 60 * 60 * 1000,
+    concurrency: 5,
     dynamic: {
-      enabled: process.env.DYNAMIC_CONCURRENCY === 'true',
-      min: parseInt(process.env.SCHED_DYNAMIC_MIN || '1', 10),
-      max: parseInt(process.env.SCHED_MAX_CONCURRENCY || '10', 10),
-      cpuThreshold: parseFloat(process.env.SCHED_CPU_THRESHOLD || '0.7'),
-      memThreshold: parseFloat(process.env.SCHED_MEM_THRESHOLD || '0.8')
+      enabled: false,
+      min: 1,
+      max: 10,
+      cpuThreshold: 0.7,
+      memThreshold: 0.8
     }
   },
   queues: {
-    llmConcurrency: parseInt(process.env.LLM_CONCURRENCY || '2', 10),
-    whisperConcurrency: parseInt(process.env.WHISPER_CONCURRENCY || '1', 10),
-    memoryThresholdGB: parseInt(process.env.QUEUE_MEM_THRESHOLD_GB || '4', 10),
-    memoryCheckInterval: parseInt(process.env.MEM_CHECK_INTERVAL || '1000', 10)
+    llmConcurrency: 2,
+    whisperConcurrency: 1,
+    memoryThresholdGB: 4,
+    memoryCheckInterval: 1000
   },
   feeds: {
-    checkInterval: parseInt(process.env.FEED_CHECK_INTERVAL || String(30 * 60 * 1000), 10)
+    checkInterval: 30 * 60 * 1000
   },
   llm: {
-    model: process.env.LLM_MODEL || 'granite3.2:latest',
-    imageModel: process.env.LLM_IMAGE_MODEL || 'llava:7b',
-    maxTokens: parseInt(process.env.LLM_MAX_TOKENS || '3000', 10),
+    model: 'granite3.2:latest',
+    imageModel: 'llava:7b',
+    maxTokens: 3000,
     host: OLLAMA_HOST
   },
   audio: {
-    sampleRate: parseInt(process.env.AUDIO_SAMPLE_RATE || '16000', 10),
-    model: process.env.WHISPER_MODEL || 'medium',
-    language: process.env.AUDIO_LANGUAGE || 'pt'
+    sampleRate: 16000,
+    model: 'medium',
+    language: 'pt'
   },
   // Novas configurações para ElevenLabs
   elevenlabs: {
-    apiKey: process.env.ELEVENLABS_API_KEY,
-    voiceId: process.env.ELEVENLABS_VOICE_ID,
-    modelId: process.env.ELEVENLABS_MODEL_ID || 'eleven_multilingual_v2',
-    stability: parseFloat(process.env.ELEVENLABS_STABILITY || '0.5'),
-    similarityBoost: parseFloat(process.env.ELEVENLABS_SIMILARITY || '0.75')
+    apiKey: '',
+    voiceId: '',
+    modelId: 'eleven_multilingual_v2',
+    stability: 0.5,
+    similarityBoost: 0.75
   },
   // Configurações para TTS local usando Piper
   piper: {
-    enabled: process.env.PIPER_ENABLED === 'true' || !!process.env.PIPER_MODEL,
-    executable: process.env.PIPER_EXECUTABLE || 'piper',
-    model: process.env.PIPER_MODEL || ''
+    enabled: false,
+    executable: 'piper',
+    model: ''
   },
   calorieApi: {
-    url: process.env.CALORIE_API_URL || 'https://api.api-ninjas.com/v1/nutrition?query=',
-    key: process.env.CALORIE_API_KEY || ''
+    url: 'https://api.api-ninjas.com/v1/nutrition?query=',
+    key: ''
   },
   google: {
-    clientId: process.env.GOOGLE_CLIENT_ID || '',
-    clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-    redirect: process.env.GOOGLE_REDIRECT || 'http://localhost:3000/oauth2callback'
+    clientId: '',
+    clientSecret: '',
+    redirect: 'http://localhost:3000/oauth2callback'
   },
   // Configurações para login no LinkedIn
   linkedin: {
-    user: process.env.LINKEDIN_USER || '',
-    pass: process.env.LINKEDIN_PASS || '',
-    liAt: process.env.LINKEDIN_LI_AT || '',
-    timeoutMs: parseInt(process.env.LINKEDIN_TIMEOUT_MS || '30000', 10)
+    user: '',
+    pass: '',
+    liAt: '',
+    timeoutMs: 30000
   }
 };
 


### PR DESCRIPTION
## Summary
- keep default configuration constants independent from .env
- add script to initialize MongoDB collections
- register `setup` script in package.json
- update README with new setup instructions

## Testing
- `npm test` *(fails: Cannot find package 'yt-dlp-wrap')*

------
https://chatgpt.com/codex/tasks/task_e_685b2d2ae024832cbcb21c82df2bb990