### PR TITLE
Show DB config in UI

### DIFF
--- a/src/api/restApi.js
+++ b/src/api/restApi.js
@@ -14,7 +14,7 @@ import VideoProcessor from '../services/video/VideoProcessor.js';
 import CalorieService from '../services/calorieService.js';
 import GoogleCalendarService from '../services/googleCalendarService.js';
 import Utils from '../utils/index.js';
-import { CONFIG, COMMANDS, CONFIG_DESCRIPTIONS, CONFIG_ENV_MAP } from '../config/index.js';
+import { CONFIG, COMMANDS, CONFIG_DESCRIPTIONS } from '../config/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -564,17 +564,28 @@ class RestAPI {
     this.app.get('/config', async (req, res) => {
       const saved = await this.configService.getConfig();
 
-      const getNested = (obj, pathStr) =>
-        pathStr.split('.').reduce((o, k) => (o || {})[k], obj);
+      const flatten = (obj, prefix = '') => {
+        const out = {};
+        for (const [k, v] of Object.entries(obj || {})) {
+          const path = prefix ? `${prefix}.${k}` : k;
+          if (v && typeof v === 'object' && !Array.isArray(v)) {
+            Object.assign(out, flatten(v, path));
+          } else {
+            out[path] = v;
+          }
+        }
+        return out;
+      };
 
-      const env = {};
+      const config = flatten(saved);
       const descriptions = {};
-      for (const [cfgPath, envVar] of Object.entries(CONFIG_ENV_MAP)) {
-        env[envVar] = getNested(saved, cfgPath);
-        descriptions[envVar] = CONFIG_DESCRIPTIONS[cfgPath];
+      for (const key of Object.keys(config)) {
+        if (CONFIG_DESCRIPTIONS[key]) {
+          descriptions[key] = CONFIG_DESCRIPTIONS[key];
+        }
       }
 
-      res.render('config', { env, descriptions });
+      res.render('config', { config, descriptions, rawConfig: saved });
     });
 
     this.app.post('/config', async (req, res) => {
@@ -593,12 +604,11 @@ class RestAPI {
         curr[keys[keys.length - 1]] = value;
       };
 
-      for (const [cfgPath, envVar] of Object.entries(CONFIG_ENV_MAP)) {
-        if (req.body[envVar] === undefined) continue;
-        let val = req.body[envVar];
+      for (const [cfgPath, valStr] of Object.entries(req.body)) {
+        let val = valStr;
         const currentVal = getNested(CONFIG, cfgPath);
-        if (typeof currentVal === 'number') val = Number(val);
-        if (typeof currentVal === 'boolean') val = val === 'true';
+        if (typeof currentVal === 'number') val = Number(valStr);
+        if (typeof currentVal === 'boolean') val = valStr === 'true';
         setNested(saved, cfgPath, val);
       }
 

--- a/src/api/restApi.js
+++ b/src/api/restApi.js
@@ -14,7 +14,7 @@ import VideoProcessor from '../services/video/VideoProcessor.js';
 import CalorieService from '../services/calorieService.js';
 import GoogleCalendarService from '../services/googleCalendarService.js';
 import Utils from '../utils/index.js';
-import { CONFIG, COMMANDS, CONFIG_DESCRIPTIONS } from '../config/index.js';
+import { CONFIG, COMMANDS, CONFIG_DESCRIPTIONS, CONFIG_ENV_MAP } from '../config/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -578,14 +578,23 @@ class RestAPI {
       };
 
       const config = flatten(saved);
+      const defaults = flatten(CONFIG);
       const descriptions = {};
+      const envMap = {};
+      const examples = {};
       for (const key of Object.keys(config)) {
         if (CONFIG_DESCRIPTIONS[key]) {
           descriptions[key] = CONFIG_DESCRIPTIONS[key];
         }
+        if (CONFIG_ENV_MAP[key]) {
+          envMap[key] = CONFIG_ENV_MAP[key];
+        }
+        if (defaults[key] !== undefined) {
+          examples[key] = defaults[key];
+        }
       }
 
-      res.render('config', { config, descriptions, rawConfig: saved });
+      res.render('config', { config, descriptions, envMap, examples, rawConfig: saved });
     });
 
     this.app.post('/config', async (req, res) => {

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -6,6 +6,9 @@
         <% if (descriptions[key]) { %>
           <small class="form-text text-muted"><%= descriptions[key] %></small>
         <% } %>
+        <% if (envMap[key]) { %>
+          <small class="form-text text-muted">Exemplo: <code><%= envMap[key] %>=<%= examples[key] %></code></small>
+        <% } %>
         <input type="text" class="form-control" name="<%= key %>" value="<%= config[key] %>">
       </div>
   <% } %>

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -1,13 +1,15 @@
 <h2>Configurações da aplicação</h2>
 <form action="/config" method="POST">
-  <% for(const key in env){ %>
-    <div class="mb-3">
-      <label class="form-label"><%= key %></label>
-      <% if (descriptions[key]) { %>
-        <small class="form-text text-muted"><%= descriptions[key] %></small>
-      <% } %>
-      <input type="text" class="form-control" name="<%= key %>" value="<%= env[key] %>">
-    </div>
+  <% for(const key in config){ %>
+      <div class="mb-3">
+        <label class="form-label"><%= key %></label>
+        <% if (descriptions[key]) { %>
+          <small class="form-text text-muted"><%= descriptions[key] %></small>
+        <% } %>
+        <input type="text" class="form-control" name="<%= key %>" value="<%= config[key] %>">
+      </div>
   <% } %>
   <button type="submit" class="btn btn-primary mt-3">Salvar</button>
 </form>
+<h3 class="mt-5">Configuração atual do banco</h3>
+<pre><code><%= JSON.stringify(rawConfig, null, 2) %></code></pre>


### PR DESCRIPTION
## Summary
- expose raw database config in `/config`
- display config JSON on config page
- allow editing every config field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b3f211778832ca61c97a9eafe42f8