### PR TITLE
Move Ollama host to DB config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ DYNAMIC_CONCURRENCY=false
 SCHED_MAX_CONCURRENCY=10
 SCHED_CPU_THRESHOLD=0.7
 SCHED_MEM_THRESHOLD=0.8
-OLLAMA_HOST=http://127.0.0.1:11434
+OLLAMA_HOST=
 # tempo máximo para receber os headers do Ollama (ms)
 OLLAMA_TIMEOUT_MS=60000
 CALORIE_API_URL=https://api.api-ninjas.com/v1/nutrition?query=

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ As variáveis serão gravadas na coleção `config`. O aplicativo não lê o `.e
 PORT=3000
 
 # 🤖 Ollama/LLM
-OLLAMA_HOST=http://127.0.0.1:11434
+OLLAMA_HOST=<url_do_servidor_ollama>
 OLLAMA_TIMEOUT_MS=60000
 LLM_CONCURRENCY=2
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -40,7 +40,7 @@ const CONFIG = {
     model: 'granite3.2:latest',
     imageModel: 'llava:7b',
     maxTokens: 3000,
-    host: 'http://127.0.0.1:11434'
+    host: ''
   },
   audio: {
     sampleRate: 16000,

--- a/src/core/whatsAppBot.js
+++ b/src/core/whatsAppBot.js
@@ -26,7 +26,6 @@ import {
   PROMPTS,
   __dirname
 } from '../config/index.js';
-const ollamaClient = new Ollama({ host: CONFIG.llm.host });
 
 // Importar o serviço TTS
 import TtsService from '../services/ttsService.js';
@@ -42,6 +41,7 @@ class WhatsAppBot {
     this.llmService = llmService;
     this.transcriber = transcriber;
     this.ttsService = ttsService; // CORREÇÃO: Atribuir o serviço TTS
+    this.ollamaClient = new Ollama({ host: CONFIG.llm.host });
     this.chatModes = new Map();
     this.userPreferences = new Map(); // Para armazenar preferências (ex: { voiceResponse: true/false })
     this.linkedinSessions = new Map(); // contato -> li_at
@@ -667,7 +667,7 @@ async handleRecursoCommand(contactId) {
         mode = 'description';
       }
       await this.sendResponse(contactId, processingMessage, true); // Status sempre em texto
-      const response = await ollamaClient.generate({
+      const response = await this.ollamaClient.generate({
         model: CONFIG.llm.imageModel,
         prompt: prompt,
         images: [imagePath],
@@ -802,7 +802,7 @@ async handleRecursoCommand(contactId) {
         console.log(`🎤 Áudio recebido no menu. Mapeando transcrição "${transcription}" para comando...`);
         await this.sendResponse(contactId, '🤔 Interpretando comando de áudio...', true);
         const commandPrompt = PROMPTS.audioCommandMapping(transcription);
-        const response = await ollamaClient.chat({
+        const response = await this.ollamaClient.chat({
             model: CONFIG.llm.model,
             messages: [{ role: 'user', content: commandPrompt }],
             options: { temperature: 0.2 }


### PR DESCRIPTION
## Summary
- store placeholder for llm host instead of loopback address
- update env example and README to use a generic host
- instantiate Ollama client after runtime config loads

## Testing
- `npm test` *(fails: cannot find package 'yt-dlp-wrap')*

------
https://chatgpt.com/codex/tasks/task_e_685b45daf570832c90390f7122040c4d