### PR TITLE
Update YouTube.js and fix transcript parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,12 +30,18 @@
         "qrcode-terminal": "^0.12.0",
         "systeminformation": "^5.27.1",
         "whatsapp-web.js": "^1.23.0",
-        "youtubei.js": "^6.0.1",
+        "youtubei.js": "14.0.0",
         "ytdl-core": "^4.11.5"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.2.tgz",
+      "integrity": "sha512-foZ7qr0IsUBjzWIq+SuBLfdQCpJ1j8cTuNNT4owngTHoN5KsJb8L9t65fzz7SCeSWzescoOil/0ldqiL041ABg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
@@ -2202,9 +2208,9 @@
       "license": "MIT"
     },
     "node_modules/jintr": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jintr/-/jintr-1.2.0.tgz",
-      "integrity": "sha512-OYPVJPlDih+G7LXjnLR5Brsz8ClxkXYn0ZmWyJVIUmFI6lySQu/dzpGRK/ujBLAYCvuJu/VqXzf84C1edowbLg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jintr/-/jintr-3.3.1.tgz",
+      "integrity": "sha512-nnOzyhf0SLpbWuZ270Omwbj5LcXUkTcZkVnK8/veJXtSZOiATM5gMZMdmzN75FmTyj+NVgrGaPdH12zIJ24oIA==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],
@@ -4177,15 +4183,16 @@
       }
     },
     "node_modules/youtubei.js": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-6.4.1.tgz",
-      "integrity": "sha512-GVrDkJmF5t378SeDiZPEAoegZ1pxjbEzNyXTuiQnL5LzPSZKA3IoJwL8lBNlRMKyksI5RbieoHzULsEt4AIbFw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-14.0.0.tgz",
+      "integrity": "sha512-KAFttOw+9fwwBUvBc1T7KzMNBLczDOuN/dfote8BA9CABxgx8MPgV+vZWlowdDB6DnHjSUYppv+xvJ4VNBLK9A==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],
       "license": "MIT",
       "dependencies": {
-        "jintr": "^1.1.0",
+        "@bufbuild/protobuf": "^2.0.0",
+        "jintr": "^3.3.1",
         "tslib": "^2.5.0",
         "undici": "^5.19.1"
       }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,18 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
+    "ejs": "^3.1.9",
     "elevenlabs": "^1.59.0",
     "express": "^4.19.2",
+    "express-ejs-layouts": "^2.5.1",
     "fluent-ffmpeg": "^2.1.3",
+    "googleapis": "^131.0.0",
     "gpt-3-encoder": "^1.1.4",
     "mammoth": "^1.9.1",
+    "method-override": "^3.0.0",
     "mongodb": "^6.6.2",
+    "multer": "^1.4.5-lts.1",
+    "node-ical": "^0.16.0",
     "nodejs-whisper": "^0.2.9",
     "ollama": "^0.5.1",
     "p-limit": "^6.2.0",
@@ -36,13 +42,7 @@
     "qrcode-terminal": "^0.12.0",
     "systeminformation": "^5.27.1",
     "whatsapp-web.js": "^1.23.0",
-    "express-ejs-layouts": "^2.5.1",
-    "method-override": "^3.0.0",
-    "googleapis": "^131.0.0",
-    "node-ical": "^0.16.0",
-    "multer": "^1.4.5-lts.1",
-    "youtubei.js": "^6.0.1",
-    "ytdl-core": "^4.11.5",
-    "ejs": "^3.1.9"
+    "youtubei.js": "14.0.0",
+    "ytdl-core": "^4.11.5"
   }
 }

--- a/src/services/youtubeService.js
+++ b/src/services/youtubeService.js
@@ -97,7 +97,7 @@ async function fetchTranscript(url) {
     const transcriptInfo = await info.getTranscript();
     const segments = transcriptInfo?.transcript?.content?.body?.initial_segments || [];
     if (segments.length) {
-      return segments.map((s) => s.text).join(' ');
+      return segments.map((s) => s.snippet?.text ?? s.text).join(' ');
     }
   } catch (err) {
     console.warn('Transcrição via YouTube.js falhou, utilizando Whisper:', err.message);


### PR DESCRIPTION
## Summary
- upgrade `youtubei.js` dependency to `14.0.0`
- adjust transcript extraction for new library format

## Testing
- `npm test` *(fails: browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cc1075b44832c81e0f6c226b21aa5