### PR TITLE
Increase Ollama timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ MONGO_URI=mongodb://bot:senha@localhost:27017/sched
 
 # 🤖 Ollama/LLM
 OLLAMA_HOST=http://127.0.0.1:11434
-OLLAMA_TIMEOUT_MS=60000
+OLLAMA_TIMEOUT_MS=600000 # 10 minutos
 LLM_CONCURRENCY=2
 
 # 🎤 Audio/TTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - PORT=3000
       - OLLAMA_HOST=http://ollama:11434
       # aumenta o timeout do Undici para aguardar o carregamento do modelo
-      - OLLAMA_TIMEOUT_MS=120000
+      - OLLAMA_TIMEOUT_MS=600000
       - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
       - ELEVENLABS_VOICE_ID=${ELEVENLABS_VOICE_ID}
     volumes:

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -3,11 +3,10 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const OLLAMA_HOST = process.env.OLLAMA_HOST;
+const OLLAMA_TIMEOUT_MS = process.env.OLLAMA_TIMEOUT_MS || '600000';
 
-if (process.env.OLLAMA_TIMEOUT_MS) {
-  process.env.UNDICI_HEADERS_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-  process.env.UNDICI_BODY_TIMEOUT = process.env.OLLAMA_TIMEOUT_MS;
-}
+process.env.UNDICI_HEADERS_TIMEOUT = OLLAMA_TIMEOUT_MS;
+process.env.UNDICI_BODY_TIMEOUT = OLLAMA_TIMEOUT_MS;
 
 export const CONFIG = {
   mongo: {
@@ -41,7 +40,8 @@ export const CONFIG = {
     model: process.env.LLM_MODEL || 'granite3.2:latest',
     imageModel: process.env.LLM_IMAGE_MODEL || 'llava:7b',
     maxTokens: parseInt(process.env.LLM_MAX_TOKENS || '3000', 10),
-    host: OLLAMA_HOST
+    host: OLLAMA_HOST,
+    timeoutMs: parseInt(OLLAMA_TIMEOUT_MS, 10)
   },
   audio: {
     sampleRate: parseInt(process.env.AUDIO_SAMPLE_RATE || '16000', 10),


### PR DESCRIPTION
## Summary
- bump default OLLAMA_TIMEOUT_MS to 600000 (10min)
- propagate the value via CONFIG.llm.timeoutMs
- document the longer timeout in README and docker-compose

## Testing
- `npm test` *(fails: Cannot find package `p-limit` imported from jobQueue.js)*

------
https://chatgpt.com/codex/tasks/task_e_685f40cb673c832cbf9deb98e0cc4249