### PR TITLE
Fix nsig youtube download errors

### DIFF
--- a/src/services/youtubeService.js
+++ b/src/services/youtubeService.js
@@ -23,6 +23,10 @@ async function initClient() {
   return ytClientPromise;
 }
 
+function shouldUseYtDlp(err) {
+  return /Could not extract functions|nsig extraction failed/i.test(String(err));
+}
+
 async function downloadAudioBuffer(youtubeUrl) {
   const outputPath = path.join(__dirname, `audio_${Date.now()}.ogg`);
   const attemptYtdl = () => new Promise((resolve, reject) => {
@@ -80,7 +84,7 @@ async function downloadAudioBuffer(youtubeUrl) {
   try {
     return await attemptYtdl();
   } catch (err) {
-    if (/Could not extract functions/.test(String(err))) {
+    if (shouldUseYtDlp(err)) {
       try {
         return await attemptYtDlp();
       } catch (e) {
@@ -140,4 +144,4 @@ async function fetchTranscriptWhisperOnly(url) {
   return transcript;
 }
 
-export default { fetchTranscript, fetchTranscriptWhisperOnly };
+export default { fetchTranscript, fetchTranscriptWhisperOnly, shouldUseYtDlp };

--- a/test/youtubeService.test.js
+++ b/test/youtubeService.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import YouTubeService from '../src/services/youtubeService.js';
+
+test('shouldUseYtDlp detects extraction errors', () => {
+  assert.equal(YouTubeService.shouldUseYtDlp(new Error('Could not extract functions')),
+    true);
+  assert.equal(YouTubeService.shouldUseYtDlp(new Error('nsig extraction failed: throttle')),
+    true);
+  assert.equal(YouTubeService.shouldUseYtDlp(new Error('other error')), false);
+});


### PR DESCRIPTION
## Summary
- handle youtube nsig errors with yt-dlp fallback
- expose helper for tests
- add regression test for nsig fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f478ce560832c858e0f149befc848