### PR TITLE
Fix Telegram startup errors

### DIFF
--- a/src/services/telegramIntegrationService.js
+++ b/src/services/telegramIntegrationService.js
@@ -6,10 +6,10 @@ import  LinkedInScraper  from './linkedinScraper.js';
 import  YouTubeService  from './youtubeService.js';
 import  Scheduler from './scheduler.js';
 import logger from '../utils/logger.js';
-import  config  from '../config/config.js';
+import { config } from '../config/config.js';
 import fs from 'fs';
 import path from 'path';
-import  fileURLToPath  from 'url';
+import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
## Summary
- add a `LinkedInScraper` class with a default export
- correct imports in `telegramIntegrationService`

## Testing
- `npm install`
- `npm test`
- `npm start` *(fails: connect ECONNREFUSED 127.0.0.1:27017)*

------
https://chatgpt.com/codex/tasks/task_e_6861f9ce9c04832cbb266c5bcace7051