### PR TITLE
Improve error logging serialization

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -17,10 +17,17 @@ class Logger {
     return this.levels[level] <= this.levels[this.currentLevel];
   }
 
+  _serializeContext(context) {
+    if (context instanceof Error) {
+      return { message: context.message, stack: context.stack };
+    }
+    return context;
+  }
+
   _formatMessage(level, message, context = null) {
     const timestamp = new Date().toISOString();
-    const contextStr = context ? ` [${JSON.stringify(context)}]` : '';
-    return `[${timestamp}] ${level}: ${message}${contextStr}`;
+    const serialized = context ? ` [${JSON.stringify(this._serializeContext(context))}]` : '';
+    return `[${timestamp}] ${level}: ${message}${serialized}`;
   }
 
   error(message, context = null) {
@@ -73,7 +80,7 @@ class Logger {
   // Method to replace console.log with conditional logging based on debug settings
   log(message, context = null, emoji = '🤖') {
     if (this.debugEnabled) {
-      const contextStr = context ? ` [${JSON.stringify(context)}]` : '';
+      const contextStr = context ? ` [${JSON.stringify(this._serializeContext(context))}]` : '';
       const timestamp = new Date().toISOString();
       console.log(`${emoji} [${timestamp}] ${message}${contextStr}`);
     }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -52,3 +52,20 @@ test('Logger banner should format correctly', () => {
   assert.ok(capturedOutput.includes('🤖 Test App'));
   assert.ok(capturedOutput.includes('v1.0'));
 });
+
+test('Logger should serialize Error objects', () => {
+  const originalError = console.error;
+  let capturedOutput = '';
+
+  console.error = (message) => {
+    capturedOutput = message;
+  };
+
+  const err = new Error('Something went wrong');
+  logger.error('Failure', err);
+
+  console.error = originalError;
+
+  assert.ok(capturedOutput.includes('Something went wrong'));
+  assert.ok(capturedOutput.includes('Failure'));
+});


### PR DESCRIPTION
## Summary
- better error serialization in logger
- test logger with Error object

## Testing
- `npm test` *(fails: test suite failing due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865cec1ee54832ca8ee285eeecf8794