### PR TITLE
Fix feature toggles textarea mapping

### DIFF
--- a/src/config/metadata.js
+++ b/src/config/metadata.js
@@ -142,6 +142,7 @@ export const CONFIG_ENV_MAP = {
   'telegram.features.dualVideoSummary': 'TELEGRAM_FEATURE_DUAL_VIDEO_SUMMARY',
   'telegram.features.voiceResponseToggle': 'TELEGRAM_FEATURE_VOICE_RESPONSE_TOGGLE',
   'telegram.features.advancedFileProcessing': 'TELEGRAM_FEATURE_ADVANCED_FILE_PROCESSING',
+  'featureToggles.features': 'FEATURE_TOGGLES_FEATURES',
   'featureToggles.enabled': 'FEATURE_TOGGLES_ENABLED'
 };
 

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -408,7 +408,7 @@
                           
                           <div class="mb-3">
                             <label class="form-label fw-bold">Configuração JSON</label>
-                            <textarea class="form-control" name="featureToggles.features" placeholder="<%= examples['featureToggles.features'] %>" rows="4"><%= typeof env['featureToggles.features'] === 'object' ? JSON.stringify(env['featureToggles.features'], null, 2) : env['featureToggles.features'] %></textarea>
+                            <textarea class="form-control" name="FEATURE_TOGGLES_FEATURES" placeholder="<%= examples['featureToggles.features'] %>" rows="4"><%= env['FEATURE_TOGGLES_FEATURES'] || JSON.stringify(featureToggles.features || {}, null, 2) %></textarea>
                             <small class="form-text text-muted">JSON com features toggles globais. Ex: {"feature1": true, "feature2": false}</small>
                           </div>
                           
@@ -598,7 +598,7 @@ function validateConfig() {
   }
   
   // Validar JSON de feature toggles
-  const featureTogglesJson = document.querySelector('textarea[name="featureToggles.features"]');
+  const featureTogglesJson = document.querySelector('textarea[name="FEATURE_TOGGLES_FEATURES"]');
   if (featureTogglesJson && featureTogglesJson.value) {
     try {
       JSON.parse(featureTogglesJson.value);


### PR DESCRIPTION
## Summary
- map `featureToggles.features` to a new env name so it loads and saves
- show the stored feature toggles JSON on the config page

## Testing
- `npm test` *(fails: Cannot find package 'nodejs-whisper')*

------
https://chatgpt.com/codex/tasks/task_e_686744e71e84832ca8e329811224f45a