### PR TITLE
Fix analyticsService import and exports

### DIFF
--- a/src/services/analyticsService.js
+++ b/src/services/analyticsService.js
@@ -1,5 +1,5 @@
-const { MongoClient } = require('mongodb');
-const config = require('../config/config');
+import { MongoClient } from 'mongodb';
+import { CONFIG } from '../config/index.js';
 
 class AnalyticsService {
     constructor() {
@@ -13,9 +13,9 @@ class AnalyticsService {
 
     async connect() {
         if (!this.client) {
-            this.client = new MongoClient(config.MONGODB_URI);
+            this.client = new MongoClient(CONFIG.mongo.uri);
             await this.client.connect();
-            this.db = this.client.db(config.DB_NAME);
+            this.db = this.client.db(CONFIG.mongo.dbName);
             await this.ensureCollections();
         }
         return this.db;
@@ -269,4 +269,4 @@ class AnalyticsService {
     }
 }
 
-module.exports = new AnalyticsService();
+export default new AnalyticsService();


### PR DESCRIPTION
## Summary
- convert `analyticsService.js` from CommonJS to ES module
- update Mongo client configuration to use global CONFIG

## Testing
- `npm test` *(fails: Cannot find package 'nodejs-whisper' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68710b49d074832c8747b416a29e0d9e